### PR TITLE
feat: support input json in dp test

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -371,6 +371,13 @@ def main_parser() -> argparse.ArgumentParser:
         type=str,
         help="The path to the datafile, each line of which is a path to one data system.",
     )
+    parser_tst_subgroup.add_argument(
+        "-i",
+        "--input-json",
+        default=None,
+        type=str,
+        help="The training input json file. Validation data in the training script will be used for testing.",
+    )
     parser_tst.add_argument(
         "-S",
         "--set-prefix",


### PR DESCRIPTION
## Summary
- add `--input-json` flag to `dp test`
- allow testing using validation data from training input JSON
- test new flag
- handle `rglob_patterns` in validation systems when using `--input-json`

## Testing
- `pre-commit run --files deepmd/entrypoints/test.py source/tests/pt/test_dp_test.py`
- `pytest source/tests/pt/test_dp_test.py::TestDPTestSeA::test_dp_test_input_json -q`
- `pytest source/tests/pt/test_dp_test.py::TestDPTestSeASpin::test_dp_test_input_json -q`
- `pytest source/tests/pt/test_dp_test.py::TestDPTestSeARglob::test_dp_test_input_json_rglob -q`


------
https://chatgpt.com/codex/tasks/task_b_688c66f97bd88332b5145f69cb8ff00d