### PR TITLE
Refactor test data selection flags

### DIFF
--- a/deepmd/main.py
+++ b/deepmd/main.py
@@ -372,18 +372,22 @@ def main_parser() -> argparse.ArgumentParser:
         help="The path to the datafile, each line of which is a path to one data system.",
     )
     parser_tst_subgroup.add_argument(
-        "-i",
-        "--input-json",
+        "--train-data",
+        dest="train_json",
         default=None,
         type=str,
-        help="The training input json file. Validation data in the training script will be used for testing.",
+        help=(
+            "The input json file. Training data in the file will be used for testing."
+        ),
     )
-    parser_tst.add_argument(
-        "--train-data",
-        "--train",
-        action="store_true",
-        dest="use_train",
-        help="Use training data in the input json file instead of validation data.",
+    parser_tst_subgroup.add_argument(
+        "--valid-data",
+        dest="valid_json",
+        default=None,
+        type=str,
+        help=(
+            "The input json file. Validation data in the file will be used for testing."
+        ),
     )
     parser_tst.add_argument(
         "-S",

--- a/source/tests/common/test_argument_parser.py
+++ b/source/tests/common/test_argument_parser.py
@@ -322,6 +322,32 @@ class TestParserOutput(unittest.TestCase):
 
         self.run_test(command="test", mapping=ARGS)
 
+    def test_parser_test_train_data(self) -> None:
+        """Test test subparser with train-data."""
+        ARGS = {
+            "--model": {"type": str, "value": "MODEL.PB"},
+            "--train-data": {
+                "type": (str, type(None)),
+                "value": "INPUT.JSON",
+                "dest": "train_json",
+            },
+        }
+
+        self.run_test(command="test", mapping=ARGS)
+
+    def test_parser_test_valid_data(self) -> None:
+        """Test test subparser with valid-data."""
+        ARGS = {
+            "--model": {"type": str, "value": "MODEL.PB"},
+            "--valid-data": {
+                "type": (str, type(None)),
+                "value": "INPUT.JSON",
+                "dest": "valid_json",
+            },
+        }
+
+        self.run_test(command="test", mapping=ARGS)
+
     def test_parser_compress(self) -> None:
         """Test compress subparser."""
         ARGS = {

--- a/source/tests/pt/test_dp_test.py
+++ b/source/tests/pt/test_dp_test.py
@@ -51,10 +51,10 @@ class DPTest:
             val_sys = val_sys[0]
         dp_test(
             model=tmp_model.name,
-            system=val_sys,
+            system=None if use_input_json else val_sys,
             datafile=None,
-            input_json=self.input_json if use_input_json else None,
-            use_train=use_train,
+            train_json=self.input_json if use_input_json and use_train else None,
+            valid_json=self.input_json if use_input_json and not use_train else None,
             set_prefix="set",
             numb_test=numb_test,
             rand_seed=None,
@@ -191,9 +191,9 @@ class TestDPTestSeARglob(unittest.TestCase):
         torch.jit.save(model, tmp_model.name)
         dp_test(
             model=tmp_model.name,
-            system=self.config["training"]["validation_data"]["systems"],
+            system=None,
             datafile=None,
-            input_json=self.input_json,
+            valid_json=self.input_json,
             set_prefix="set",
             numb_test=1,
             rand_seed=None,
@@ -246,10 +246,9 @@ class TestDPTestSeARglobTrain(unittest.TestCase):
         torch.jit.save(model, tmp_model.name)
         dp_test(
             model=tmp_model.name,
-            system=self.config["training"]["validation_data"]["systems"],
+            system=None,
             datafile=None,
-            input_json=self.input_json,
-            use_train=True,
+            train_json=self.input_json,
             set_prefix="set",
             numb_test=1,
             rand_seed=None,


### PR DESCRIPTION
## Summary
- replace `--input-json`/`--train-data` with new `--train-data` and `--valid-data` flags for `dp test`
- update testing entrypoint to load training or validation systems based on new flags
- adjust PyTorch tests and CLI parser tests to exercise new interface

## Testing
- `pre-commit run --files deepmd/main.py deepmd/entrypoints/test.py source/tests/common/test_argument_parser.py source/tests/pt/test_dp_test.py`
- `pytest source/tests/pt/test_dp_test.py source/tests/common/test_argument_parser.py`


------
https://chatgpt.com/codex/tasks/task_b_68b143344bb8833284d70ab0161b5afc